### PR TITLE
Add pulseaudio socket to allow audio output

### DIFF
--- a/com.gitlab.newsflash.json
+++ b/com.gitlab.newsflash.json
@@ -12,6 +12,7 @@
         "--share=ipc",
         "--socket=fallback-x11",
         "--socket=wayland",
+        "--socket=pulseaudio",
         "--device=dri",
         "--talk-name=org.freedesktop.Notifications",
         "--filesystem=xdg-download"


### PR DESCRIPTION
Solves issue https://gitlab.com/news-flash/news_flash_gtk/-/issues/135 (NewsFlash packaged as Flatpak does not play audio sources).