### PR TITLE
Update GNOME runtime to 40 & drop libhandy dep

### DIFF
--- a/com.gitlab.newsflash.json
+++ b/com.gitlab.newsflash.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "com.gitlab.newsflash",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "3.38",
+    "runtime-version" : "40",
     "sdk" : "org.gnome.Sdk",
     "sdk-extensions" : [
         "org.freedesktop.Sdk.Extension.rust-stable"
@@ -29,29 +29,6 @@
         }
     },
     "modules" : [
-        {
-            "name" : "libhandy",
-            "buildsystem" : "meson",
-            "config-opts" : [
-                "-Dintrospection=disabled",
-                "-Dgtk_doc=false",
-                "-Dtests=false",
-                "-Dexamples=false",
-                "-Dvapi=false",
-                "-Dglade_catalog=disabled"
-            ],
-            "cleanup" : [
-              "/include",
-              "/lib/pkgconfig"
-            ],
-            "sources" : [
-                {
-                    "type" : "git",
-                    "url" : "https://gitlab.gnome.org/GNOME/libhandy",
-                    "tag": "1.0.2"
-                }
-            ]
-        },
         {
             "name" : "newsflash",
             "buildsystem" : "meson",


### PR DESCRIPTION
libhandy now is a part of new GNOME 40 runtime.